### PR TITLE
Fixed bug in the example of using apt-key

### DIFF
--- a/docs/en/getting_started/index.md
+++ b/docs/en/getting_started/index.md
@@ -28,7 +28,7 @@ Then run these commands to actually install packages:
 
 ```bash
 sudo apt-get install dirmngr    # optional
-sudo apt-key adv --keyserver keyserver.ubuntu.com --recv E0C56BD4    # optional
+sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv E0C56BD4    # optional
 sudo apt-get update
 sudo apt-get install clickhouse-client clickhouse-server
 ```


### PR DESCRIPTION
Original error:
$ sudo apt-key adv --keyserver keyserver.ubuntu.com --recv E0C56BD4
Executing: /tmp/apt-key-gpghome.g8OJxK1FMy/gpg.1.sh --keyserver keyserver.ubuntu.com --recv E0C56BD4
gpg: keyserver receive failed: Server indicated a failure